### PR TITLE
Add border-box rule to html selector and replace * box-sizing to inherit

### DIFF
--- a/predefined/_box-sizing.scss
+++ b/predefined/_box-sizing.scss
@@ -1,7 +1,10 @@
 @if $global-box-sizing == true {
+	html {
+		box-sizing: border-box;
+	}
 	*,
 	*:before,
 	*:after {
-		box-sizing: border-box;
+		box-sizing: inherit;
 	}
 }


### PR DESCRIPTION
Following the advice in [this article](https://css-tricks.com/inheriting-box-sizing-probably-slightly-better-best-practice/): setting the box-sizing property directly on the `*` selector prevents components from easily setting their own `box-sizing` model, so we put the mode we want as default on the `html` selector instead and set `*` to inherit.
